### PR TITLE
🐛 Fix undefined variable post_type_deleted

### DIFF
--- a/wp-graphql-custom-post-type-ui.php
+++ b/wp-graphql-custom-post-type-ui.php
@@ -75,7 +75,7 @@ class WPGraphQL_CPT_UI {
 		
 		if ( 'edit' === $tab ) {
 			$post_types = cptui_get_post_type_data();
-			$selected_post_type = cptui_get_current_post_type( $post_type_deleted );
+			$selected_post_type = cptui_get_current_post_type( false );
 			if ( $selected_post_type ) {
 				if ( array_key_exists( $selected_post_type, $post_types ) ) {
 					$current = $post_types[ $selected_post_type ];


### PR DESCRIPTION
Issue #4 

Fix the `Notice: Undefined variable: post_type_deleted in /app/public/wp-content/plugins/wp-graphql-custom-post-type-ui-master/wp-graphql-custom-post-type-ui.php on line 78`