### PR TITLE
Release v1.2.0

### DIFF
--- a/wp-graphql-custom-post-type-ui.php
+++ b/wp-graphql-custom-post-type-ui.php
@@ -1,97 +1,181 @@
 <?php
 /**
-* Plugin Name: WPGraphQL Custom Post Type UI
-* Description: Adds WPGraphQL settings to Custom Post Type UI
-* Author: WPGraphQL, rachelbahl, jasonbahl
-* Author URI: https://wpgraphql.com
-* Version: 1.1
-* Text Domain: wp-graphql-custom-post-type-ui
-* Requires at least: 5.1.0
-* Tested up to: 5.2.0
-* Requires PHP: 5.6
-* License: GPL-3
-* License URI: https://www.gnu.org/licenses/gpl-3.0.html
-*/
+ * Plugin Name: WPGraphQL Custom Post Type UI
+ * Description: Adds WPGraphQL settings to Custom Post Type UI
+ * Author: WPGraphQL, rachelbahl, jasonbahl
+ * Author URI: https://wpgraphql.com
+ * Version: 1.2.0
+ * Text Domain: wp-graphql-custom-post-type-ui
+ * Requires at least: 5.1.0
+ * Tested up to: 5.2.0
+ * Requires PHP: 5.6
+ * License: GPL-3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
-* This class creates settings for Custom Post Type UI to show Custom Post Types in GraphQL
-*/
-
+ * This class creates settings for Custom Post Type UI to show Custom Post Types in GraphQL
+ */
 class WPGraphQL_CPT_UI {
 
+	/**
+	 * @var bool
+	 */
 	protected $show_in_graphql = false;
+
+	/**
+	 * @var string
+	 */
 	protected $graphql_single_name = '';
+
+	/**
+	 * @var string
+	 */
 	protected $graphql_plural_name = '';
 
 	/**
-	* Initializes the plugin functionality
-	*/
+	 * Initializes the plugin functionality
+	 */
 	public function init() {
-	    // Taxonmies
-		add_action( 'cptui_taxonomy_after_fieldsets', [ $this, 'add_taxonomy_graphql_settings' ], 10, 1 );
+
+		// Taxonomies
+		add_action( 'cptui_taxonomy_after_fieldsets', [
+			$this,
+			'add_taxonomy_graphql_settings'
+		], 10, 1 );
 		add_filter( 'cptui_before_update_taxonomy', [ $this, 'before_update_taxonomy' ], 10, 2 );
-		add_filter( 'cptui_pre_register_taxonomy', [ $this, 'add_graphql_settings_to_registry' ], 10, 3 );
+		add_filter( 'cptui_pre_register_taxonomy', [
+			$this,
+			'add_graphql_settings_to_registry'
+		], 10, 3 );
 		add_filter( 'cptui_pre_save_taxonomy', [ $this, 'save_graphql_settings' ], 10, 2 );
 
 		// Post Types
-		add_action( 'cptui_post_type_after_fieldsets', [ $this, 'add_graphql_posty_type_settings' ], 10, 1 );
+		add_action( 'cptui_post_type_after_fieldsets', [
+			$this,
+			'add_graphql_post_type_settings'
+		], 10, 1 );
 		add_filter( 'cptui_before_update_post_type', [ $this, 'before_update_post_type' ], 10, 2 );
-		add_filter( 'cptui_pre_register_post_type', [ $this, 'add_graphql_settings_to_registry' ], 10, 3 );
+		add_filter( 'cptui_pre_register_post_type', [
+			$this,
+			'add_graphql_settings_to_registry'
+		], 10, 3 );
 		add_filter( 'cptui_pre_save_post_type', [ $this, 'save_graphql_settings' ], 10, 2 );
 	}
 
 	/**
-	* Set defaults for post type and taxonomy settings
-	*/
-	public function add_graphql_settings_to_registry( $args, $name, $type ) {
-		$args['show_in_graphql' ] = isset( $type['show_in_graphql'] ) ? (bool) $type['show_in_graphql'] : false;
-		$args['graphql_single_name' ] = ! empty( $type['graphql_single_name'] ) ?  $type['graphql_single_name'] : null;
-		$args['graphql_plural_name' ] = ! empty( $type['graphql_plural_name'] ) ?  $type['graphql_plural_name'] : null;
+	 * Set defaults for post type and taxonomy settings
+	 *
+	 * @param array  $args The args for the registry
+	 * @param string $name The name of the type
+	 * @param array  $type The array that composes the Type
+	 *
+	 * @return array
+	 */
+	public function add_graphql_settings_to_registry( array $args, string $name, array $type ): array {
+
+		if ( ! isset( $type['show_in_graphql'] ) || true !== (bool) $type['show_in_graphql'] ) {
+			return $args;
+		}
+
+		if ( ! isset( $type['graphql_plural_name'] ) || empty( $type['graphql_plural_name'] ) ) {
+			graphql_debug( sprintf( __( 'The graphql_plural_name is empty for the "%s" Post Type or Taxonomy.' ), $type['name'] ) );
+			return $args;
+		}
+
+		if ( ! isset( $type['graphql_single_name'] ) || empty( $type['graphql_single_name'] ) ) {
+			graphql_debug( sprintf( __( 'The graphql_single_name is empty for the "%s" Post Type or Taxonomy.' ), $type['name'] ) );
+			return $args;
+		}
+
+
+		$args['show_in_graphql']     = isset( $type['show_in_graphql'] ) ? (bool) $type['show_in_graphql'] : false;
+		$args['graphql_single_name'] = ! empty( $type['graphql_single_name'] ) ? $type['graphql_single_name'] : null;
+		$args['graphql_plural_name'] = ! empty( $type['graphql_plural_name'] ) ? $type['graphql_plural_name'] : null;
+
 		return $args;
 	}
 
 	/**
-	* Capture post type settings from form submission for saving
-	*/
-	public function before_update_post_type( $data ) {
-		$this->show_in_graphql = isset( $data[ 'cpt_custom_post_type' ]['show_in_graphql'] ) ? $data[ 'cpt_custom_post_type' ]['show_in_graphql'] : false;
-		$this->graphql_single_name = isset( $data[ 'cpt_custom_post_type' ]['graphql_single_name'] ) ? $data[ 'cpt_custom_post_type' ]['graphql_single_name'] : '';
-		$this->graphql_plural_name = isset( $data[ 'cpt_custom_post_type' ]['graphql_plural_name'] ) ? $data[ 'cpt_custom_post_type' ]['graphql_plural_name'] : '';
+	 * Capture post type settings from form submission for saving
+	 *
+	 * @param array $data
+	 */
+	public function before_update_post_type( array $data ) {
+
+		if ( ! isset( $data['cpt_custom_post_type']['graphql_single_name'] ) || empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		if ( ! isset( $data['cpt_custom_post_type']['graphql_plural_name'] ) || empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		if ( ! isset( $data['cpt_custom_post_type']['show_in_graphql'] ) || empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		$this->show_in_graphql     = ! empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ? $data['cpt_custom_post_type']['show_in_graphql'] : false;
+		$this->graphql_single_name = ! empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_single_name'] ) : '';
+		$this->graphql_plural_name = ! empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_plural_name'] ) : '';
 	}
 
 	/**
 	 * Capture taxonomy settings from form submission for saving
+	 *
+	 * @param array $data
 	 */
-	public function before_update_taxonomy( $data ) {
-		$this->show_in_graphql = isset( $data[ 'cpt_custom_tax' ]['show_in_graphql'] ) ? $data[ 'cpt_custom_tax' ]['show_in_graphql'] : false;
-		$this->graphql_single_name = isset( $data[ 'cpt_custom_tax' ]['graphql_single_name'] ) ? $data[ 'cpt_custom_tax' ]['graphql_single_name'] : '';
-		$this->graphql_plural_name = isset( $data[ 'cpt_custom_tax' ]['graphql_plural_name'] ) ? $data[ 'cpt_custom_tax' ]['graphql_plural_name'] : '';
+	public function before_update_taxonomy( array $data ) {
+
+		if ( ! isset( $data['cpt_custom_tax']['graphql_single_name'] ) || empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		if ( ! isset( $data['cpt_custom_tax']['graphql_plural_name'] ) || empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		if ( ! isset( $data['cpt_custom_tax']['show_in_graphql'] ) || empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ) {
+			$this->show_in_graphql = false;
+		}
+
+		$this->show_in_graphql     = ! empty( $data['cpt_custom_tax']['show_in_graphql'] ) ? $data['cpt_custom_tax']['show_in_graphql'] : false;
+		$this->graphql_single_name = ! empty( $data['cpt_custom_tax']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_single_name'] ) : '';
+		$this->graphql_plural_name = ! empty( $data['cpt_custom_tax']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_plural_name'] ) : '';
 	}
 
 	/**
-	* Save values from form submission
-	*/
-	public function save_graphql_settings( $type, $name ) {
-		$type[ $name ]['show_in_graphql'] = $this->show_in_graphql;
-		$type[ $name ]['graphql_single_name'] = $this->graphql_single_name;
-		$type[ $name ]['graphql_plural_name'] = $this->graphql_plural_name;
+	 * Save values from form submission
+	 *
+	 * @param array  $type
+	 * @param string $name
+	 *
+	 * @return array
+	 */
+	public function save_graphql_settings( array $type, string $name ): array {
+		$type[ $name ]['show_in_graphql']     = $this->show_in_graphql;
+		$type[ $name ]['graphql_single_name'] = \WPGraphQL\Utils\Utils::format_type_name( $this->graphql_single_name );
+		$type[ $name ]['graphql_plural_name'] = \WPGraphQL\Utils\Utils::format_type_name( $this->graphql_plural_name );
+
 		return $type;
 	}
 
 
 	/**
-	* Add settings fields to Custom Post Type UI form
-	*/
-	public function add_graphql_posty_type_settings( $ui ) {
-
-		$tab = ( ! empty( $_GET ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) ? 'edit' : 'new';
-
+	 * Add settings fields to Custom Post Type UI form
+	 *
+	 * @param cptui_admin_ui $ui Admin UI instance
+	 */
+	public function add_graphql_post_type_settings( cptui_admin_ui $ui ) {
+		$tab        = ( ! empty( $_GET ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) ? 'edit' : 'new';
+		$current    = [];
+		$name_array = 'cpt_custom_post_type';
 		if ( 'edit' === $tab ) {
-			$post_types = cptui_get_post_type_data();
+			$post_types         = cptui_get_post_type_data();
 			$selected_post_type = cptui_get_current_post_type( false );
 			if ( $selected_post_type ) {
 				if ( array_key_exists( $selected_post_type, $post_types ) ) {
@@ -99,71 +183,20 @@ class WPGraphQL_CPT_UI {
 				}
 			}
 		}
-
-		?>
-		<div class="cptui-section postbox">
-				<button type="button" class="handlediv button-link" aria-expanded="true">
-					<span class="screen-reader-text"><?php esc_html_e( 'Toggle panel: GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
-					<span class="toggle-indicator" aria-hidden="true"></span>
-				</button>
-				<h2 class="hndle">
-					<span><?php esc_html_e( 'GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
-				</h2>
-				<div class="inside">
-					<div class="main">
-						<table class="form-table cptui-table">
-							<?php
-
-								$select = array(
-								'options' => array(
-									array( 'attr' => '0', 'text' => esc_attr__( 'False', 'wp-graphql-custom-post-type-ui' ) ),
-									array( 'attr' => '1', 'text' => esc_attr__( 'True', 'wp-graphql-custom-post-type-ui' ), 'default' => 'true' ),
-								),
-							);
-
-							$selected = ( isset( $current ) && ! empty( $current['show_in_graphql'] ) ) ? disp_boolean( $current['show_in_graphql'] ) : '';
-							$select['selected'] = ( ! empty( $selected ) && ! empty( $current['show_in_graphql'] ) ) ? $current['show_in_graphql'] : '';
-							echo $ui->get_select_input( array(
-								'namearray'  => 'cpt_custom_post_type',
-								'name'       => 'show_in_graphql',
-								'labeltext'  => esc_html__( 'Show in GraphQL', 'wp-graphql-custom-post-type-ui' ),
-								'aftertext'  => esc_html__( '(Custom Post Type UI default: true) Whether or not to show this post type data in the WP GraphQL.', 'wp-graphql-custom-post-type-ui' ),
-								'selections' => $select,
-							) );
-
-
-							echo $ui->get_text_input( array(
-								'namearray' => 'cpt_custom_post_type',
-								'name'      => 'graphql_single_name',
-								'labeltext' => esc_html__( 'GraphQL Single Name', 'wp-graphql-custom-post-type-ui' ),
-								'aftertext' => esc_attr__( 'Single name for this Post Type in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
-								'textvalue' => ( isset( $current['graphql_single_name'] ) ) ? esc_attr( $current['graphql_single_name'] ) : '',
-							) );
-
-							echo $ui->get_text_input( array(
-								'namearray' => 'cpt_custom_post_type',
-								'name'      => 'graphql_plural_name',
-								'labeltext' => esc_html__( 'GraphQL Plural Name', 'wp-graphql-custom-post-type-ui' ),
-								'aftertext' => esc_attr__( 'Plural name for this Post Type in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
-								'textvalue' => ( isset( $current['graphql_plural_name'] ) ) ? esc_attr( $current['graphql_plural_name'] ) : '',
-							) );
-							?>
-						</table>
-					</div>
-				</div>
-		</div>
-		<?php
+		echo $this->get_setting_fields( $ui, $current, $name_array );
 	}
 
 	/**
 	 * Add settings fields to Custom Post Type UI form
+	 *
+	 * @param cptui_admin_ui $ui Admin UI instance
 	 */
-	public function add_taxonomy_graphql_settings( $ui ) {
-
-		$tab = ( ! empty( $_GET ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) ? 'edit' : 'new';
-
+	public function add_taxonomy_graphql_settings( cptui_admin_ui $ui ) {
+		$tab        = ( ! empty( $_GET ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) ? 'edit' : 'new';
+		$name_array = 'cpt_custom_tax';
+		$current    = [];
 		if ( 'edit' === $tab ) {
-			$taxonomies = cptui_get_taxonomy_data();
+			$taxonomies        = cptui_get_taxonomy_data();
 			$selected_taxonomy = cptui_get_current_taxonomy( false );
 			if ( $selected_taxonomy ) {
 				if ( array_key_exists( $selected_taxonomy, $taxonomies ) ) {
@@ -171,64 +204,154 @@ class WPGraphQL_CPT_UI {
 				}
 			}
 		}
+		echo $this->get_setting_fields( $ui, $current, $name_array );
+	}
 
+	/**
+	 * Get the settings fields to render for the form
+	 *
+	 * @param cptui_admin_ui $ui Admin UI instance
+	 * @param array          $current
+	 * @param string         $name_array
+	 */
+	public function get_setting_fields( cptui_admin_ui $ui, array $current, string $name_array ) {
 		?>
-        <div class="cptui-section postbox">
-            <button type="button" class="handlediv button-link" aria-expanded="true">
-                <span class="screen-reader-text"><?php esc_html_e( 'Toggle panel: GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
-                <span class="toggle-indicator" aria-hidden="true"></span>
-            </button>
-            <h2 class="hndle">
-                <span><?php esc_html_e( 'GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
-            </h2>
-            <div class="inside">
-                <div class="main">
-                    <table class="form-table cptui-table">
+		<div class="cptui-section postbox">
+			<div class="postbox-header">
+
+				<h2 class="hndle ui-sortable-handle">
+					<span><?php esc_html_e( 'GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
+				</h2>
+				<div class="handle-actions hide-if-no-js">
+					<button type="button" class="handlediv">
+						<span class="screen-reader-text"><?php esc_html_e( 'Toggle panel: GraphQL Settings', 'wp-graphql-custom-post-type-ui' ); ?></span>
+						<span class="toggle-indicator" aria-hidden="true"></span>
+					</button>
+				</div>
+			</div>
+			<div class="inside">
+				<div class="main">
+					<table class="form-table cptui-table">
 						<?php
 
-						$select = array(
-							'options' => array(
-								array( 'attr' => '0', 'text' => esc_attr__( 'False', 'wp-graphql-custom-post-type-ui' ) ),
-								array( 'attr' => '1', 'text' => esc_attr__( 'True', 'wp-graphql-custom-post-type-ui' ), 'default' => 'true' ),
-							),
-						);
+						$selections = [
+							'options' => [
+								[
+									'attr' => '0',
+									'text' => esc_attr__( 'False', 'wp-graphql-custom-post-type-ui' )
+								],
+								[
+									'attr' => '1',
+									'text' => esc_attr__( 'True', 'wp-graphql-custom-post-type-ui' ),
+								],
+							],
+						];
 
-						$selected = ( isset( $current ) && ! empty( $current['show_in_graphql'] ) ) ? disp_boolean( $current['show_in_graphql'] ) : '';
-						$select['selected'] = ( ! empty( $selected ) && ! empty( $current['show_in_graphql'] ) ) ? $current['show_in_graphql'] : '';
-						echo $ui->get_select_input( array(
+						$selected               = ( isset( $current ) && ! empty( $current['show_in_graphql'] ) ) ? disp_boolean( $current['show_in_graphql'] ) : '';
+						$selections['selected'] = ( ! empty( $selected ) && ! empty( $current['show_in_graphql'] ) ) ? $current['show_in_graphql'] : '0';
+
+
+						echo $ui->get_select_input( [
 							'namearray'  => 'cpt_custom_tax',
 							'name'       => 'show_in_graphql',
 							'labeltext'  => esc_html__( 'Show in GraphQL', 'wp-graphql-custom-post-type-ui' ),
-							'aftertext'  => esc_html__( '(Custom Post Type UI default: true) Whether or not to show this post type data in the WP GraphQL.', 'wp-graphql-custom-post-type-ui' ),
-							'selections' => $select,
-						) );
+							'aftertext'  => esc_html__( 'Whether or not to show data of this type in the WPGraphQL. Default: false', 'wp-graphql-custom-post-type-ui' ),
+							'selections' => $selections,
+							'required'   => true,
+							'default'    => false,
+						] );
 
 
-						echo $ui->get_text_input( array(
+						echo $ui->get_text_input( [
 							'namearray' => 'cpt_custom_tax',
 							'name'      => 'graphql_single_name',
 							'labeltext' => esc_html__( 'GraphQL Single Name', 'wp-graphql-custom-post-type-ui' ),
-							'aftertext' => esc_attr__( 'Single name for this Post Type in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
+							'aftertext' => esc_attr__( 'Singular name for reference in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
 							'textvalue' => ( isset( $current['graphql_single_name'] ) ) ? esc_attr( $current['graphql_single_name'] ) : '',
-						) );
+							'required'  => true,
+						] );
 
-						echo $ui->get_text_input( array(
+						echo $ui->get_text_input( [
 							'namearray' => 'cpt_custom_tax',
 							'name'      => 'graphql_plural_name',
 							'labeltext' => esc_html__( 'GraphQL Plural Name', 'wp-graphql-custom-post-type-ui' ),
-							'aftertext' => esc_attr__( 'Plural name for this Post Type in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
+							'aftertext' => esc_attr__( 'Plural name for reference in the GraphQL API.', 'wp-graphql-custom-post-type-ui' ),
 							'textvalue' => ( isset( $current['graphql_plural_name'] ) ) ? esc_attr( $current['graphql_plural_name'] ) : '',
-						) );
+							'required'  => true,
+						] );
 						?>
-                    </table>
-                </div>
-            </div>
-        </div>
+					</table>
+				</div>
+			</div>
+		</div>
+		<?php
+		$this->graphql_field_helpers();
+	}
+
+	/**
+	 * JavaScript helpers to add conditional logic and support for the GraphQL setting fields
+	 */
+	public function graphql_field_helpers() {
+		// This script provides helpers for the GraphQL fields in the CPT UI screen.
+		// If the Post Type or Taxonomy is not set to show_in_graphql the single/plural names
+		// should not be required.
+		?>
+		<script type="application/javascript">
+            var singleName = document.getElementById('graphql_single_name');
+            var singleNameRow = singleName.closest('tr');
+            var pluralName = document.getElementById('graphql_plural_name');
+            var pluralNameRow = pluralName.closest('tr');
+            var showInGraphQL = document.getElementById('show_in_graphql');
+            var label = document.getElementById('label');
+            var singleLabel = document.getElementById('singular_label');
+
+            // Set the values of the GraphQL fields and their display state
+            function updateGraphQlFields() {
+
+                // Set default state for field values and display state
+                // If the show_in_graphql value is true (or '1') show the
+                // fields and set them as required
+                // Else hide the fields and leave them as not-required
+                if (showInGraphQL.value === '1') {
+                    singleName.required = true;
+                    pluralName.required = true;
+                    pluralNameRow.style.display = "table-row";
+                    singleNameRow.style.display = "table-row";
+                } else {
+                    singleName.required = false;
+                    pluralName.required = false;
+                    pluralNameRow.style.display = "none";
+                    singleNameRow.style.display = "none";
+                }
+
+                // If single_name has no value, but single_label does, use single_label as the value
+                if (!singleName.value.length) {
+                    singleName.value = singleLabel.value;
+                }
+
+                // If single_name has no value, but single_label does, use single_label as the value
+                if (!pluralName.value.length) {
+                    pluralName.value = label.value;
+                }
+            }
+
+            // Once the DOM is ready, listen for events
+            document.addEventListener("DOMContentLoaded", function () {
+                updateGraphQlFields();
+                // When the show in graphql field changes, re-apply GraphQL Field Values
+                showInGraphQL.addEventListener('input', function () {
+                    updateGraphQlFields();
+                });
+            });
+		</script>
 		<?php
 	}
 
 }
 
+/**
+ * Load WPGraphQL for CPT UI
+ */
 add_action( 'plugins_loaded', 'init_wpgraphql_cptui' );
 
 function init_wpgraphql_cptui() {

--- a/wp-graphql-custom-post-type-ui.php
+++ b/wp-graphql-custom-post-type-ui.php
@@ -68,7 +68,7 @@ class WPGraphQL_CPT_UI {
 	}
 
 	/**
-	 * Set defaults for post type and taxonomy settings
+	 * Adds the GraphQL Settings from CPT UI to the post_type and taxonomy registry args.
 	 *
 	 * @param array  $args The args for the registry
 	 * @param string $name The name of the type
@@ -78,17 +78,24 @@ class WPGraphQL_CPT_UI {
 	 */
 	public function add_graphql_settings_to_registry( array $args, string $name, array $type ): array {
 
+		// If the type is not set to show_in_graphql, return the args as-is
 		if ( ! isset( $type['show_in_graphql'] ) || true !== (bool) $type['show_in_graphql'] ) {
 			return $args;
 		}
 
+		// If the type has no graphql_plural_name, return the args as-is, but
+		// add a message to the debug log for why the Type is not in the Schema
 		if ( ! isset( $type['graphql_plural_name'] ) || empty( $type['graphql_plural_name'] ) ) {
-			graphql_debug( sprintf( __( 'The graphql_plural_name is empty for the "%s" Post Type or Taxonomy.' ), $type['name'] ) );
+			graphql_debug( sprintf( __( 'The graphql_plural_name is empty for the "%s" Post Type or Taxonomy registered by Custom Post Type UI.' ), $type['name'] ) );
+
 			return $args;
 		}
 
+		// If the type has no graphql_single_name, return the args as-is, but
+		// add a message to the debug log for why the Type is not in the Schema
 		if ( ! isset( $type['graphql_single_name'] ) || empty( $type['graphql_single_name'] ) ) {
-			graphql_debug( sprintf( __( 'The graphql_single_name is empty for the "%s" Post Type or Taxonomy.' ), $type['name'] ) );
+			graphql_debug( sprintf( __( 'The graphql_single_name is empty for the "%s" Post Type or Taxonomy registered by Custom Post Type UI.' ), $type['name'] ) );
+
 			return $args;
 		}
 
@@ -106,22 +113,9 @@ class WPGraphQL_CPT_UI {
 	 * @param array $data
 	 */
 	public function before_update_post_type( array $data ) {
-
-		if ( ! isset( $data['cpt_custom_post_type']['graphql_single_name'] ) || empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		if ( ! isset( $data['cpt_custom_post_type']['graphql_plural_name'] ) || empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		if ( ! isset( $data['cpt_custom_post_type']['show_in_graphql'] ) || empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		$this->show_in_graphql     = ! empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ? $data['cpt_custom_post_type']['show_in_graphql'] : false;
-		$this->graphql_single_name = ! empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_single_name'] ) : '';
-		$this->graphql_plural_name = ! empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_plural_name'] ) : '';
+		$this->show_in_graphql     = isset( $data['cpt_custom_post_type']['show_in_graphql'] ) ? $data['cpt_custom_post_type']['show_in_graphql'] : false;
+		$this->graphql_single_name = isset( $data['cpt_custom_post_type']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_single_name'] ) : '';
+		$this->graphql_plural_name = isset( $data['cpt_custom_post_type']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_post_type']['graphql_plural_name'] ) : '';
 	}
 
 	/**
@@ -130,22 +124,9 @@ class WPGraphQL_CPT_UI {
 	 * @param array $data
 	 */
 	public function before_update_taxonomy( array $data ) {
-
-		if ( ! isset( $data['cpt_custom_tax']['graphql_single_name'] ) || empty( $data['cpt_custom_post_type']['graphql_single_name'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		if ( ! isset( $data['cpt_custom_tax']['graphql_plural_name'] ) || empty( $data['cpt_custom_post_type']['graphql_plural_name'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		if ( ! isset( $data['cpt_custom_tax']['show_in_graphql'] ) || empty( $data['cpt_custom_post_type']['show_in_graphql'] ) ) {
-			$this->show_in_graphql = false;
-		}
-
-		$this->show_in_graphql     = ! empty( $data['cpt_custom_tax']['show_in_graphql'] ) ? $data['cpt_custom_tax']['show_in_graphql'] : false;
-		$this->graphql_single_name = ! empty( $data['cpt_custom_tax']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_single_name'] ) : '';
-		$this->graphql_plural_name = ! empty( $data['cpt_custom_tax']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_plural_name'] ) : '';
+		$this->show_in_graphql     = isset( $data['cpt_custom_tax']['show_in_graphql'] ) ? $data['cpt_custom_tax']['show_in_graphql'] : false;
+		$this->graphql_single_name = isset( $data['cpt_custom_tax']['graphql_single_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_single_name'] ) : '';
+		$this->graphql_plural_name = isset( $data['cpt_custom_tax']['graphql_plural_name'] ) ? \WPGraphQL\Utils\Utils::format_type_name( $data['cpt_custom_tax']['graphql_plural_name'] ) : '';
 	}
 
 	/**
@@ -163,7 +144,6 @@ class WPGraphQL_CPT_UI {
 
 		return $type;
 	}
-
 
 	/**
 	 * Add settings fields to Custom Post Type UI form


### PR DESCRIPTION
## TLDR

- updates the plugin to have conditional logic for the graphql_single_name and graphql_plural_name to only show and be required if show_in_graphql is set to true.
- cleans up code formatting
- DRY up the form markup that's used for the forms
- Fixes issue with postbox header markup

## More info

This is basically a complete refactor of the plugin. 

The overall goal is to handle the fields for GraphQL settings better. 

Currently, users can leave graphql_single_name and graphql_plural_name blank, but set the Post Type or Taxonomy to show_in_graphql and that causes issues. 

This makes the graphql_single_name and graphql_plural_name fields conditional to only show and be required if show_in_graphql is set to true. 

See example: 

![show-in-graphql-cptui](https://user-images.githubusercontent.com/1260765/112345168-6b63a500-8c8a-11eb-844a-45ef3c67a669.gif)


